### PR TITLE
Fix warning/error on GCC 7

### DIFF
--- a/src/python_psfgen.c
+++ b/src/python_psfgen.c
@@ -18,8 +18,7 @@
 void python_msg(void *v, const char *msg)
 {
     v = (FILE*)v; // print to this file
-    fprintf(v, msg);
-    fprintf(v, "\n");
+    fprintf(v, "%s\n", msg);
 }
 
 /* Wrapper function for getting char* from a python string */


### PR DESCRIPTION
Hi!

When trying to build the code on Ubuntu 18.04 I get the following error:

```
$ python3 setup.py build
[lots of output omitted]
x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DPSFGENTCLDLL_EXPORTS=1 -I./src -I/usr/include/python3.6m -c ./src/python_psfgen.c -o build/temp.linux-x86_64-3.6/./src/python_psfgen.o
./src/python_psfgen.c: In function ‘python_msg’:
./src/python_psfgen.c:21:5: error: format not a string literal and no format arguments [-Werror=format-security]
     fprintf(v, msg);
     ^~~~~~~
cc1: some warnings being treated as errors
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

$ x86_64-linux-gnu-gcc --version
x86_64-linux-gnu-gcc (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0
```

The compiler warning-treated-as-error seems to be warranted, so I adjusted the `fprintf` statement to use pre-defined format. Don't think it can break anything.