### PR TITLE
Fix potential leak of FILE* in py_write_psf

### DIFF
--- a/src/python_psfgen.c
+++ b/src/python_psfgen.c
@@ -366,12 +366,6 @@ static PyObject* py_write_psf(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!data || PyErr_Occurred())
         return NULL;
 
-    fd = fopen(filename, "w");
-    if (!fd) {
-        PyErr_Format(PyExc_OSError, "cannot open psf file '%s' for writing",
-                     filename);
-        return NULL;
-    }
     if (!strcasecmp(type, "charmm")) {
         charmmfmt = 1;
     } else if (!strcasecmp(type, "x-plor")) {
@@ -379,6 +373,13 @@ static PyObject* py_write_psf(PyObject *self, PyObject *args, PyObject *kwargs)
     } else {
         PyErr_Format(PyExc_ValueError, "psf format '%s' not in [charmm,x-plor]",
                      type);
+        return NULL;
+    }
+
+    fd = fopen(filename, "w");
+    if (!fd) {
+        PyErr_Format(PyExc_OSError, "cannot open psf file '%s' for writing",
+                     filename);
         return NULL;
     }
 


### PR DESCRIPTION
If `type` has an invalid value (neither `charmm` nor `x-plor`), the function would return without closing
open file.

I moved the check of `type` value before we try to open the file. This way, if the value is invalid the function will return before opening the file. Also, I feel like it's better to check the validity of arguments as soon as possible.